### PR TITLE
✨feat(`src/services/logger.service.ts`): Now use DestinationStream instead of node stream. Acording to the docs this provides a +30% performance and it's a drop-in replacement.

### DIFF
--- a/ejercicio-3/src/services/logger.service.ts
+++ b/ejercicio-3/src/services/logger.service.ts
@@ -1,4 +1,4 @@
-import pino, { LoggerOptions } from 'pino'
+import pino, { DestinationStream, LoggerOptions } from 'pino'
 import path from 'path'
 import fs from 'fs'
 
@@ -13,20 +13,21 @@ class LoggerService {
   private readonly logFilePath: string = path.join(
     this.logsDir, this.logFileName
   )
-  private readonly stream: fs.WriteStream
+  private readonly stream: DestinationStream
 
   /** Default constructor.
    *  It ensures 'logsDir' is created and the stream opened. */
   constructor() {
     fs.mkdirSync(this.logsDir, { recursive: true })
-    this.stream = fs.createWriteStream(
-      this.logFilePath,
-      { flags: 'a' } // 'append' instead of re-creating the log per session.
-    )
+    this.stream = pino.destination({
+      dest: this.logFilePath,
+      minLength: 4096,
+      sync: false
+    })
   }
 
   /** Returns a logger object with our default opts. */
-  getLogger(): pino.Logger{
+  getLogger(): pino.Logger {
     // Set logger options
     const loggerOpts: LoggerOptions = {
       level: process.env.PINO_LOG_LEVEL || 'info',


### PR DESCRIPTION
Also it provides us control of how many bytes we should buffer before writing into disk.